### PR TITLE
Allow caching of auth token across client instantiations

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -29,7 +29,12 @@ class Client extends BaseClient
     /** @var array */
     private $groups;
 
-    public function __construct(array $config = [])
+    /**
+     * @param array $config
+     * @param string|null $token pre-seeded token for auth
+     * @param callable|null $saveToken takes token string as param, should save with a TTL of two hours
+     */
+    public function __construct(array $config = [], string $token = null, callable $saveToken = null)
     {
         $connectionData                    = $config['connection'];
         $connectionData['base_uri']        = $connectionData['api_url'];
@@ -38,7 +43,7 @@ class Client extends BaseClient
 
         parent::__construct($connectionData);
 
-        $this->authenticator = new GreenropeAuthenticator($connectionData);
+        $this->authenticator = new GreenropeAuthenticator($connectionData, $token, $saveToken);
 
         $this->groups = $config['groups'];
     }

--- a/src/Service/GreenropeAuthenticator.php
+++ b/src/Service/GreenropeAuthenticator.php
@@ -25,9 +25,14 @@ class GreenropeAuthenticator extends Client
     /** @var string */
     private $token;
 
-    public function __construct(array $config)
+    /** @var callable */
+    private $saveToken;
+
+    public function __construct(array $config, string $token = null, callable $saveToken = null)
     {
         $this->xmlSerializer = new XmlSerializer();
+        $this->token = $token;
+        $this->saveToken = $saveToken;
 
         parent::__construct($config);
     }
@@ -51,6 +56,9 @@ class GreenropeAuthenticator extends Client
 
         if (!empty($token = $response->getResult())) {
             $this->token = $token;
+            if (is_callable($this->saveToken)) {
+                ($this->saveToken)($this->token);
+            }
 
             return $this->token;
         } else {


### PR DESCRIPTION
Creator is responsible for having a proper TTL (two hours) on the cache entry on the token if $saveToken is specified.

In our use case, we're wrapping Laravel's Cache methods to persist the access token with the proper TTL.