### PR TITLE
Add client method to get account IDs associated with a user

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -72,6 +72,24 @@ class Client extends BaseClient
         return new $class($this, $this->authenticator);
     }
 
+    public function getAccountIds()
+    {
+        $response = $this->post($this->getConfig('base_uri'), [
+            'form_params' => [
+                'email'      => $this->getConfig('email'),
+                'auth_token' => $this->authenticator->getAuthToken(),
+                'xml'        => '<GetAccountsWithAccessRequest response="json"></GetAccountsWithAccessRequest>',
+            ],
+        ]);
+
+        $json = json_decode($response->getBody()->getContents(), JSON_OBJECT_AS_ARRAY);
+
+        return array_slice(
+            array_column($json['getaccountswithaccessresponse']['accounts']['account'], 'accountnumber'),
+            1 // filter out account default GreenRope account ID
+        );
+    }
+
     public function getGroup(string $name)
     {
         return $this->groups[$name];


### PR DESCRIPTION
Skips first account ID since that's the base GreenRope account, based on what I saw in the response I got back.