### PR TITLE
Don't try to cast Done_date to a datetime

### DIFF
--- a/src/Model/CrmActivity.php
+++ b/src/Model/CrmActivity.php
@@ -111,7 +111,7 @@ class CrmActivity extends AbstractModel
     /**
      * @Serializer\XmlElement(cdata=false)
      * @Serializer\SkipWhenEmpty()
-     * @Serializer\Type("DateTime<'Y-m-d H:i:s'>")
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("Done_date")
      */
     protected $doneDate;


### PR DESCRIPTION
Format is Y-m-d H:i, and value may be blank (which doesn't play nice
with the null check on JMSSeralizer). Switching to the same semantics
as Due_Date, namely "keep it as a string".