### PR TITLE
Move PHPUnit to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,10 @@
     "type": "library",
     "require": {
         "guzzlehttp/guzzle": "^6.3",
-        "phpunit/phpunit": "^6.0|^7.0",
         "jms/serializer": "^1.13"
     },
     "license": "MIT",
-    "autoload":          {
+    "autoload": {
         "psr-4": {
             "Sctr\\Greenrope\\Api\\": "src"
         }
@@ -20,6 +19,7 @@
     },
     "minimum-stability": "stable",
     "require-dev": {
+        "phpunit/phpunit": "^6.0|^7.0",
         "squizlabs/php_codesniffer": "^3.3"
     }
 }


### PR DESCRIPTION
Allows use of e.g. PHPUnit 8 in projects that depend on this lib without needing to revise tests for development here.